### PR TITLE
fix: use Status.WARN instead of ERROR

### DIFF
--- a/packages/textlint/src/extension.ts
+++ b/packages/textlint/src/extension.ts
@@ -67,7 +67,7 @@ File will not be validated. Consider running the 'Create .textlintrc file' comma
       );
     });
     client.onNotification(NoLibraryNotification.type, (p) => {
-      statusBar.status = Status.ERROR;
+      statusBar.status = Status.WARN;
       statusBar.status.log(
         client,
         `Failed to load the textlint library in ${p.workspaceFolder} .


### PR DESCRIPTION
This PR is a cherry-pick of https://github.com/taichi/vscode-textlint/pull/67.

> If ERROR is set to ERROR, the OUTPUT panel opens, so use WARNING instead.
>
> This PR changes the behaviour when opening a project without textlint installed.