### PR TITLE
chore: add .github/release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+changelog:
+  exclude:
+    labels:
+      - 'Type: Meta'
+      - 'Type: Question'
+      - 'Type: Release'
+
+  categories:
+    - title: Security Fixes
+      labels: ['Type: Security']
+    - title: Breaking Changes
+      labels: ['Type: Breaking Change']
+    - title: Features
+      labels: ['Type: Feature']
+    - title: Bug Fixes
+      labels: ['Type: Bug']
+    - title: Documentation
+      labels: ['Type: Documentation']
+    - title: Refactoring
+      labels: ['Type: Refactoring']
+    - title: Testing
+      labels: ['Type: Testing']
+    - title: Maintenance
+      labels: ['Type: Maintenance']
+    - title: CI
+      labels: ['Type: CI']
+    - title: Dependency Updates
+      labels: ['Type: Dependencies', "dependencies"]
+    - title: Other Changes
+      labels: ['*']


### PR DESCRIPTION
Added same settings as textlint/textlint.
Labeling PRs and [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) will give you a clean output.

- setup labels to repository.
- add `.github/release.yml`

cc @3w36zj6 