### PR TITLE
docs: add link to Visual Studio Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 Extension to integrate [textlint](https://textlint.github.io/) into VSCode.
 
+## How to install
+
+1. Visit [Visual Studio Code: textlint](https://marketplace.visualstudio.com/items?itemName=3w36zj6.textlint)
+2. Click Install
+
 ## Development setup
 
 1. open `vscode-textlint.code-workspace` by VS Code


### PR DESCRIPTION
I just add link to https://marketplace.visualstudio.com/items?itemName=3w36zj6.textlint from README.