### PR TITLE
chore: bump version to 0.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9186,7 +9186,7 @@
       }
     },
     "packages/textlint": {
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "minimatch": "^3.0.4",
@@ -9211,12 +9211,12 @@
         "webpack-cli": "^4.9.1"
       },
       "engines": {
-        "vscode": "^1.61.0"
+        "vscode": "^1.74.0"
       }
     },
     "packages/textlint-server": {
       "name": "vscode-textlint-server",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "glob": "^7.2.0",

--- a/packages/textlint-server/package.json
+++ b/packages/textlint-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-textlint-server",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Textlint Linter Server",
   "repository": {
     "type": "git",

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "textlint",
   "displayName": "textlint",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Integrates textlint into VS Code.",
   "categories": [
     "Linters"


### PR DESCRIPTION
This pull request includes version updates for two packages.

Version updates:

* [`packages/textlint-server/package.json`](diffhunk://#diff-631fc64c14abb5cb92bc306598e4d823d3bddf1a269d422e5e819e43f2b64c9dL3-R3): Updated the version from `0.12.0` to `0.12.1`.
* [`packages/textlint/package.json`](diffhunk://#diff-2d8f6910e95a5ff15d520d44b87838027f8a6b4971e3c253c917cc432d5159a5L4-R4): Updated the version from `0.12.0` to `0.12.1`.