### PR TITLE
fix: correct article usage in configuration path descriptions

### DIFF
--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -66,12 +66,12 @@
         "textlint.configPath": {
           "type": "string",
           "default": null,
-          "description": "A absolute path to textlint config file."
+          "description": "An absolute path to textlint config file."
         },
         "textlint.ignorePath": {
           "type": "string",
           "default": null,
-          "description": "A absolute path to textlint ignore file."
+          "description": "An absolute path to textlint ignore file."
         },
         "textlint.nodePath": {
           "type": "string",


### PR DESCRIPTION
First of all, thank you so much for maintaining this amazing project.
I truly appreciate the work, attention to detail, and the value it provides to the community. 🙏

This PR makes a very minor change in packages/textlint/package.json —
fixing the article usage from "A absolute" to "An absolute" in the description.

I realize this is a tiny and non-critical change, and I’m sorry for the trivial nature of the PR 😅
Still, I thought it might help keep the documentation polished and consistent.

Thank you again for all your incredible work on this project,
and I hope this small contribution can be of use! 🙇‍♂️