### PR TITLE
ci: add job to run TypeScript checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        task: [format, lint]
+        task: [format, lint, type-check]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "clean": "npm run clean --ws",
     "tsc": "npm run tsc --ws",
+    "type-check": "npm exec --ws -- tsc --noEmit",
     "build": "webpack --mode production",
     "watch": "webpack --mode development --watch",
     "test": "npm run test --ws --if-present",


### PR DESCRIPTION
This pull request adds a new type-checking step to the CI pipeline to help catch TypeScript errors earlier and improve code quality.