### PR TITLE
feat: associate textlint config files with languages

### DIFF
--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -42,6 +42,12 @@
         "command": "textlint.showOutputChannel"
       }
     ],
+    "configurationDefaults": {
+      "files.associations": {
+        ".textlintrc.json": "jsonc",
+        ".textlintignore": "ignore"
+      }
+    },
     "configuration": {
       "type": "object",
       "title": "textlint",


### PR DESCRIPTION
## Changes

This PR adds default language associations for textlint configuration files.

### `.textlintrc.json`

`.textlintrc.json` files are parsed as JSON5 by `azu/rc-config-loader`, but VS Code treats them as regular JSON by default. As a result, JSON5 features such as comments are reported as invalid syntax, which is noisy.

Ideally, these files would be associated with JSON5. However, VS Code does not provide built-in JSON5 syntax support, so this PR associates them with JSON with Comments as a practical compromise.

### `.textlintignore`

`.textlintignore` files are associated with the ignore language.