### PR TITLE
fix: remove redundant rule id from diagnostic message

### DIFF
--- a/packages/textlint-server/src/server.ts
+++ b/packages/textlint-server/src/server.ts
@@ -366,7 +366,6 @@ function toDiagnosticSeverity(severity?: number): DiagnosticSeverity {
 }
 
 function toDiagnostic(message: TextLintMessage): [TextLintMessage, Diagnostic] {
-  const txt = message.ruleId ? `${message.message} (${message.ruleId})` : message.message;
   const pos_start = Position.create(Math.max(0, message.line - 1), Math.max(0, message.column - 1));
   let offset = 0;
   if (message.message.indexOf("->") >= 0) {
@@ -378,7 +377,7 @@ function toDiagnostic(message: TextLintMessage): [TextLintMessage, Diagnostic] {
   }
   const pos_end = Position.create(Math.max(0, message.line - 1), Math.max(0, message.column - 1) + offset);
   const diag: Diagnostic = {
-    message: txt,
+    message: message.message,
     severity: toDiagnosticSeverity(message.severity),
     source: "textlint",
     range: Range.create(pos_start, pos_end),

--- a/packages/textlint/test/extension.test.ts
+++ b/packages/textlint/test/extension.test.ts
@@ -195,7 +195,7 @@ suite("Extension tests", function () {
         const expectedDiagnostics = [
           {
             code: "common-misspellings",
-            message: "This is a commonly misspelled word. Correct it to you (common-misspellings)",
+            message: "This is a commonly misspelled word. Correct it to you",
             range: {
               start: { line: 0, character: 1 },
               end: { line: 0, character: 1 },
@@ -205,7 +205,7 @@ suite("Extension tests", function () {
           },
           {
             code: "common-misspellings",
-            message: "This is a commonly misspelled word. Correct it to you (common-misspellings)",
+            message: "This is a commonly misspelled word. Correct it to you",
             range: {
               start: { line: 2, character: 0 },
               end: { line: 2, character: 0 },
@@ -215,7 +215,7 @@ suite("Extension tests", function () {
           },
           {
             code: "common-misspellings",
-            message: "This is a commonly misspelled word. Correct it to you (common-misspellings)",
+            message: "This is a commonly misspelled word. Correct it to you",
             range: {
               start: { line: 4, character: 1 },
               end: { line: 4, character: 1 },


### PR DESCRIPTION
Close #31 

<img width="605" height="140" alt="fixed" src="https://github.com/user-attachments/assets/19c5257b-f569-4641-8ea7-c96a6480aee0" />
