### PR TITLE
fix: prevent server crash when no workspace folder is open

### DIFF
--- a/packages/textlint-server/src/server.ts
+++ b/packages/textlint-server/src/server.ts
@@ -80,8 +80,8 @@ connection.onInitialized(async () => {
   });
 });
 
-async function configureEngine(folders: WorkspaceFolder[]) {
-  for (const folder of folders) {
+async function configureEngine(folders: WorkspaceFolder[] | null) {
+  for (const folder of folders ?? []) {
     TRACE(`configureEngine ${folder.uri}`);
     const root = URI.parse(folder.uri).fsPath;
     try {


### PR DESCRIPTION
Fix #29