### PR TITLE
build: migrate extension bundle to ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@textlint/types": "^15.7.1",
         "@types/glob": "^7.2.0",
         "@types/node": "^22.20.0",
-        "@types/vscode": "^1.91.0",
+        "@types/vscode": "^1.100.0",
         "@vscode/test-electron": "^3.0.0",
         "@vscode/vsce": "^3.9.2",
         "eslint": "^10.5.0",
@@ -39,7 +39,7 @@
       },
       "engines": {
         "node": ">=24.0.0 <25.0.0",
-        "vscode": "^1.91.0"
+        "vscode": "^1.100.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "license": "MIT",
   "publisher": "3w36zj6",
-  "main": "./dist/extension",
+  "type": "module",
+  "main": "./dist/extension.js",
   "scripts": {
     "clean": "rimraf dist out",
     "tsc": "tsc -p ./",
@@ -145,7 +146,7 @@
     "@textlint/types": "^15.7.1",
     "@types/glob": "^7.2.0",
     "@types/node": "^22.20.0",
-    "@types/vscode": "^1.91.0",
+    "@types/vscode": "^1.100.0",
     "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "^3.9.2",
     "eslint": "^10.5.0",
@@ -161,7 +162,7 @@
   },
   "engines": {
     "node": ">=24.0.0 <25.0.0",
-    "vscode": "^1.91.0"
+    "vscode": "^1.100.0"
   },
   "icon": "textlint-icon_128x128.png",
   "galleryBanner": {

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -1,19 +1,23 @@
 import { defineConfig } from "@rspack/cli";
+import { fileURLToPath } from "node:url";
 import path from "node:path";
+
+const rootDirectory = path.dirname(fileURLToPath(import.meta.url));
 
 const config = defineConfig({
   target: "node",
   output: {
-    path: path.resolve(__dirname, "dist"),
+    path: path.resolve(rootDirectory, "dist"),
+    module: true,
     library: {
-      type: "commonjs",
+      type: "module",
     },
   },
   stats: {
     errorDetails: true,
   },
   devtool: "source-map",
-  externalsType: "commonjs",
+  externalsType: "module-import",
   externals: [
     {
       vscode: "vscode",
@@ -21,8 +25,7 @@ const config = defineConfig({
     },
   ],
   resolve: {
-    extensions: [".ts", ".js"],
-    modules: [path.resolve(__dirname, "node_modules"), "node_modules"],
+    extensions: [".ts", "..."],
   },
   module: {
     rules: [

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -23,6 +23,7 @@ import { URI, Utils as URIUtils } from "vscode-uri";
 import * as os from "os";
 import * as fs from "fs";
 import * as path from "path";
+import { createRequire } from "node:module";
 import * as glob from "glob";
 import minimatch from "minimatch";
 
@@ -149,12 +150,11 @@ async function resolveModule(root: string) {
   }
 }
 
-declare const __webpack_require__: typeof require;
-declare const __non_webpack_require__: typeof require;
+const runtimeRequire = createRequire(import.meta.url);
+
 function loadModule(moduleName: string) {
-  const r = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
   try {
-    return r(moduleName);
+    return runtimeRequire(moduleName);
   } catch (err) {
     TRACE("load failed", err);
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "target": "ES2022",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
This PR migrates the extension bundle from CommonJS to ESM.

VS Code 1.100 or later is now required[^1].

[^1]: https://code.visualstudio.com/updates/v1_100#_esm-support-for-extensions