### PR TITLE
fix: require VS Code 1.103 or later

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@rspack/core": "^2.1.1",
         "@textlint/types": "^15.7.1",
         "@types/node": "^22.20.0",
-        "@types/vscode": "^1.100.0",
+        "@types/vscode": "^1.103.0",
         "@vscode/test-electron": "^3.0.0",
         "@vscode/vsce": "^3.9.2",
         "merge-options": "^3.0.4",
@@ -40,7 +40,7 @@
       },
       "engines": {
         "node": ">=24.0.0 <25.0.0",
-        "vscode": "^1.100.0"
+        "vscode": "^1.103.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@rspack/core": "^2.1.1",
     "@textlint/types": "^15.7.1",
     "@types/node": "^22.20.0",
-    "@types/vscode": "^1.100.0",
+    "@types/vscode": "^1.103.0",
     "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "^3.9.2",
     "merge-options": "^3.0.4",
@@ -163,6 +163,6 @@
   },
   "engines": {
     "node": ">=24.0.0 <25.0.0",
-    "vscode": "^1.100.0"
+    "vscode": "^1.103.0"
   }
 }


### PR DESCRIPTION
Config file discovery uses `fs.globSync`, which was added in Node.js v22.0.0 and marked stable in v22.17.0. VS Code 1.100 bundles Node.js 20.19.0 (Electron 34), where `fs.globSync` does not exist at all, and 1.101/1.102 bundle Node.js 22.15.1, where it still emits an ExperimentalWarning to stderr.

[VS Code 1.103 bundles Node.js 22.18.0 (Electron 37)](https://code.visualstudio.com/updates/v1_103#:~:text=Chromium%20138.0.7204.100%20and-,Node.js%2022.17.0,-.%20We%20want%20to), so raise the minimum supported version accordingly.